### PR TITLE
Fix installdir location, and metadata

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,7 +15,12 @@ WriteMakefile(
     },
     MAN3PODS         => {},
     DEFINE           => '-DUSE_PPPORT_H',
-    INSTALLDIRS      => 'perl',
+
+    # 'perl' is reserved for things that shipped with the perl version;
+    # on perls after 5.011000, 'site' has precedence over 'perl', but before
+    # that 'perl' had precedence so we need to keep installing to there.
+    "$]" <= 5.011000 ? ( INSTALLDIRS => 'perl' ) : (),
+
     PREREQ_PM => {
         $have_test_requires ? () : %test_req,
     },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,12 +25,22 @@ WriteMakefile(
         $have_test_requires ? () : %test_req,
     },
     $have_test_requires ? (TEST_REQUIRES => \%test_req) : (),
+
     META_MERGE => {
+        'meta-spec' => { version => 2 },
         dynamic_config => 0,
         resources => {
-            repository  => 'git://perl5.git.perl.org/perl.git perl-git',
-            bugtracker  => 'http://rt.perl.org/perlbug/',
-            MailingList => 'http://lists.cpan.org/showlist.cgi?name=perl5-porters'
+            repository  => {
+                url => 'git://perl5.git.perl.org/perl.git',
+                web => 'https://perl5.git.perl.org/perl.git',
+                type => 'git',
+            },
+            bugtracker => {
+                mailto => 'perlbug@perl.org',
+                web => 'https://rt.perl.org',
+            },
+            x_MailingList => 'http://lists.perl.org/list/perl5-porters.html',
+            x_IRC => 'irc://irc.perl.org/#p5p',
         },
     }
 );


### PR DESCRIPTION
The INSTALLDIRS patch was mentioned in RT#128525 but was missed in the 2.160 and 2.161 releases.
